### PR TITLE
Use HTTPS instead of git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'prome', github: 'mbeloshitsky/prome'
+gem 'prome', :git => 'https://github.com/mbeloshitsky/prome.git'


### PR DESCRIPTION
Hi, not sure if that's an issue specific to our setup as I'm not familiar with Ruby, but this is how I fixed an error that kept me from using this plugin.
Bundle complained because it tried to use git:// for cloning the prome gem because that wasn't encrypted. Using HTTPS with the complete repository URL fixes that.

Also thanks for this plugin. :)